### PR TITLE
proposed improvements to the JASA quarto template

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -32,7 +32,7 @@
     title = {Discrete Multivariate Analyses: Theory and Practice},
     year = {1975},
     pages = {557},
-    publisher = {MIT Press}
+    publisher = {Boston, MA: MIT Press}
 }   
 
 

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -1,233 +1,39 @@
-%% This BibTeX bibliography file was created using BibDesk.
-%% http://bibdesk.sourceforge.net/
+@article{gelm:veht:2021,
+  author = {Andrew Gelman and Aki Vehtari},
+  title = {{What are the Most Important Statistical Ideas of the Past 50 Years?}},
+  journal = {Journal of the American Statistical Association},
+  volume = {116},
+  number = {536},
+  pages = {2087-2097},
+  year  = {2021},
+  publisher = {Taylor & Francis},
+  doi = {10.1080/01621459.2021.1938081},
+  URL = {https://doi.org/10.1080/01621459.2021.1938081},
+  eprint = {https://doi.org/10.1080/01621459.2021.1938081}
+}
+
+@article{brom:woo:2018,
+  author = {Karl W. Broman and Kara H. Woo},
+  title = {{Data Organization in Spreadsheets}},
+  journal = {The American Statistician},
+  volume = {72},
+  number = {1},
+  pages = {2-10},
+  year  = {2018},
+  publisher = {Taylor & Francis},
+  doi = {10.1080/00031305.2017.1375989},
+  URL = {https://doi.org/10.1080/00031305.2017.1375989},
+  eprint = {https://doi.org/10.1080/00031305.2017.1375989}
+}
 
 
-%% Created for Galyardt at 2014-08-21 22:49:39 -0400 
+@book{bish:fien:1975,
+    author = {Bishop, Yvonne M. M. and Fienberg, Stephen E. and Holland, Paul W.},
+    title = {Discrete Multivariate Analyses: Theory and Practice},
+    year = {1975},
+    pages = {557},
+    publisher = {MIT Press}
+}   
 
 
-%% Saved with string encoding Unicode (UTF-8) 
 
-
-
-@incollection{Galyardt14mmm,
-	Author = {April Galyardt},
-	Booktitle = {Handbook of Mixed Membership Models},
-	Date-Added = {2014-08-21 21:18:27 +0000},
-	Date-Modified = {2014-08-21 21:18:27 +0000},
-	Editor = {Edoardo M. Airoldi and David Blei and Erosheva, Elena and Fienberg, Stephen E.},
-	Publisher = {Chapman and Hall},
-	Title = {Interpreting Mixed Membership Models: Implications of Erosheva's Representation Theorem},
-	Year = {2014},
-	Bdsk-File-1 = {YnBsaXN0MDDUAQIDBAUGJCVYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoKgHCBMUFRYaIVUkbnVsbNMJCgsMDxJXTlMua2V5c1pOUy5vYmplY3RzViRjbGFzc6INDoACgAOiEBGABIAFgAdccmVsYXRpdmVQYXRoWWFsaWFzRGF0YV8QMi4uLy4uL1BhcGVyLU1NIGNoYXB0ZXIvR2FseWFyZHQtY2hhcHRlci03LjguMTMucGRm0hcLGBlXTlMuZGF0YU8RAeIAAAAAAeIAAgAADE1hY2ludG9zaCBIRAAAAAAAAAAAAAAAAAAAAMm3i1VIKwAAAJ3/thtHYWx5YXJkdC1jaGFwdGVyLTcuOC4xMy5wZGYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAu7Y5zgBejQAAAAAAAAAAAAIAAgAACSAAAAAAAAAAAAAAAAAAAAAQUGFwZXItTU0gY2hhcHRlcgAQAAgAAMm3w5UAAAARAAgAAM4Als0AAAABABAAnf+2ABefWwANUdgAAJg6AAIAVU1hY2ludG9zaCBIRDpVc2VyczoAYWdhbHlhcmR0OgBEcm9wYm94OgBQYXBlci1NTSBjaGFwdGVyOgBHYWx5YXJkdC1jaGFwdGVyLTcuOC4xMy5wZGYAAA4AOAAbAEcAYQBsAHkAYQByAGQAdAAtAGMAaABhAHAAdABlAHIALQA3AC4AOAAuADEAMwAuAHAAZABmAA8AGgAMAE0AYQBjAGkAbgB0AG8AcwBoACAASABEABIARFVzZXJzL2FnYWx5YXJkdC9Ecm9wYm94L1BhcGVyLU1NIGNoYXB0ZXIvR2FseWFyZHQtY2hhcHRlci03LjguMTMucGRmABMAAS8AABUAAgAQ//8AAIAG0hscHR5aJGNsYXNzbmFtZVgkY2xhc3Nlc11OU011dGFibGVEYXRhox0fIFZOU0RhdGFYTlNPYmplY3TSGxwiI1xOU0RpY3Rpb25hcnmiIiBfEA9OU0tleWVkQXJjaGl2ZXLRJidUcm9vdIABAAgAEQAaACMALQAyADcAQABGAE0AVQBgAGcAagBsAG4AcQBzAHUAdwCEAI4AwwDIANACtgK4Ar0CyALRAt8C4wLqAvMC+AMFAwgDGgMdAyIAAAAAAAACAQAAAAAAAAAoAAAAAAAAAAAAAAAAAAADJA==}}
-
-@phdthesis{Galyardt12dis,
-	Address = {Pittsburgh, PA 15213},
-	Author = {April Galyardt},
-	Date-Added = {2014-08-21 21:17:56 +0000},
-	Date-Modified = {2014-08-22 02:49:38 +0000},
-	Keywords = {mixed membership, Latent Dirichlet Allocation, cognitive diagnosis models, numerical estimation, psychometrics},
-	Month = {July},
-	School = {Carnegie Mellon University},
-	Title = {Mixed Membership Distributions with Applications to Modeling Multiple Strategy Usage},
-	Year = {2012},
-	Bdsk-File-1 = {YnBsaXN0MDDUAQIDBAUGJCVYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoKgHCBMUFRYaIVUkbnVsbNMJCgsMDxJXTlMua2V5c1pOUy5vYmplY3RzViRjbGFzc6INDoACgAOiEBGABIAFgAdccmVsYXRpdmVQYXRoWWFsaWFzRGF0YV8QRC4uLy4uLy4uL0RvY3VtZW50cy9QdWJsaWNhdGlvbnMvMjAxMi1HYWx5YXJkdC1EaXNzZXJ0YXRpb24tRmluYWwucGRm0hcLGBlXTlMuZGF0YU8RAfoAAAAAAfoAAgAADE1hY2ludG9zaCBIRAAAAAAAAAAAAAAAAAAAAMtppx9IKwAAAAuN+h8yMDEyLUdhbHlhcmR0LURpc3NlciMyNjgyNTgucGRmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJoJYzMbb7wAAAAAAAAAAAAMAAwAACSAAAAAAAAAAAAAAAAAAAAAMUHVibGljYXRpb25zABAACAAAy2ntbwAAABEACAAAzMciPwAAAAEAEAALjfoABcifAAXIngAAuVcAAgBXTWFjaW50b3NoIEhEOlVzZXJzOgBhZ2FseWFyZHQ6AERvY3VtZW50czoAUHVibGljYXRpb25zOgAyMDEyLUdhbHlhcmR0LURpc3NlciMyNjgyNTgucGRmAAAOAEoAJAAyADAAMQAyAC0ARwBhAGwAeQBhAHIAZAB0AC0ARABpAHMAcwBlAHIAdABhAHQAaQBvAG4ALQBGAGkAbgBhAGwALgBwAGQAZgAPABoADABNAGEAYwBpAG4AdABvAHMAaAAgAEgARAASAEtVc2Vycy9hZ2FseWFyZHQvRG9jdW1lbnRzL1B1YmxpY2F0aW9ucy8yMDEyLUdhbHlhcmR0LURpc3NlcnRhdGlvbi1GaW5hbC5wZGYAABMAAS8AABUAAgAQ//8AAIAG0hscHR5aJGNsYXNzbmFtZVgkY2xhc3Nlc11OU011dGFibGVEYXRhox0fIFZOU0RhdGFYTlNPYmplY3TSGxwiI1xOU0RpY3Rpb25hcnmiIiBfEA9OU0tleWVkQXJjaGl2ZXLRJidUcm9vdIABAAgAEQAaACMALQAyADcAQABGAE0AVQBgAGcAagBsAG4AcQBzAHUAdwCEAI4A1QDaAOIC4ALiAucC8gL7AwkDDQMUAx0DIgMvAzIDRANHA0wAAAAAAAACAQAAAAAAAAAoAAAAAAAAAAAAAAAAAAADTg==}}
-
-@conference{Galyardt13smmc,
-	Address = {Arnhem, Netherlands},
-	Author = {April Galyardt and Ilya Goldin},
-	Booktitle = {International Meeting of the Psychometric Society},
-	Date-Added = {2014-08-21 21:17:50 +0000},
-	Date-Modified = {2014-08-21 21:17:50 +0000},
-	Keywords = {conf},
-	Title = {Modeling Student Metacognitive Strategies in a Intelligent Tutoring System},
-	Year = {2013}}
-
-@article{Campbell02,
-	Author = {Jamie I.D. Campbell and Shauna Austin},
-	Date-Added = {2014-08-21 21:12:16 +0000},
-	Date-Modified = {2014-08-21 21:13:22 +0000},
-	Journal = {Memory \& Cognition},
-	Keywords = {strategies, addition, response time},
-	Number = {6},
-	Pages = {988-994},
-	Title = {Effects of response time deadlines on adults' strategy choices for simple addition},
-	Volume = {30},
-	Year = {2002}}
-
-@article{Schubert13,
-	Author = {Schubert, Christiane C and Denmark, T Kent and Crandall, Beth and Grome, Anna and Pappas, James},
-	Date-Added = {2014-08-21 21:00:46 +0000},
-	Date-Modified = {2014-08-21 21:00:46 +0000},
-	Journal = {Annals of emergency medicine},
-	Keywords = {expert/novice differences},
-	Number = {1},
-	Pages = {96--109},
-	Publisher = {Elsevier},
-	Title = {Characterizing novice-expert differences in macrocognition: an exploratory study of cognitive work in the emergency department},
-	Volume = {61},
-	Year = {2013},
-	Bdsk-File-1 = {YnBsaXN0MDDUAQIDBAUGJCVYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoKgHCBMUFRYaIVUkbnVsbNMJCgsMDxJXTlMua2V5c1pOUy5vYmplY3RzViRjbGFzc6INDoACgAOiEBGABIAFgAdccmVsYXRpdmVQYXRoWWFsaWFzRGF0YV8QYS4uLy4uL1BhcGVyLVdoYXQncyBhIFN0cmF0ZWd5L1BhcGVycy1TdHJhdGVnaWVzL1JlYWQvU2NodWJlcnQgZXRhbCAoMjAxMikgLUVtZXJnZW5jeSBNZWRpY2luZS5wZGbSFwsYGVdOUy5kYXRhTxECVAAAAAACVAACAAAMTWFjaW50b3NoIEhEAAAAAAAAAAAAAAAAAAAAybeLVUgrAAACeKY6H1NjaHViZXJ0IGV0YWwgKDIwMTIjMjc4QTdCNi5wZGYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJ4p7bP6W1eAAAAAAAAAAAAAgAEAAAJIAAAAAAAAAAAAAAAAAAAAARSZWFkABAACAAAybfDlQAAABEACAAAz+mlngAAAAEAGAJ4pjoCeKY4ANZobAAXn1sADVHYAACYOgACAHlNYWNpbnRvc2ggSEQ6VXNlcnM6AGFnYWx5YXJkdDoARHJvcGJveDoAUGFwZXItV2hhdCdzIGEgU3RyYXRlZ3k6AFBhcGVycy1TdHJhdGVnaWVzOgBSZWFkOgBTY2h1YmVydCBldGFsICgyMDEyIzI3OEE3QjYucGRmAAAOAFoALABTAGMAaAB1AGIAZQByAHQAIABlAHQAYQBsACAAKAAyADAAMQAyACkAIAAtAEUAbQBlAHIAZwBlAG4AYwB5ACAATQBlAGQAaQBjAGkAbgBlAC4AcABkAGYADwAaAAwATQBhAGMAaQBuAHQAbwBzAGgAIABIAEQAEgBzVXNlcnMvYWdhbHlhcmR0L0Ryb3Bib3gvUGFwZXItV2hhdCdzIGEgU3RyYXRlZ3kvUGFwZXJzLVN0cmF0ZWdpZXMvUmVhZC9TY2h1YmVydCBldGFsICgyMDEyKSAtRW1lcmdlbmN5IE1lZGljaW5lLnBkZgAAEwABLwAAFQACABD//wAAgAbSGxwdHlokY2xhc3NuYW1lWCRjbGFzc2VzXU5TTXV0YWJsZURhdGGjHR8gVk5TRGF0YVhOU09iamVjdNIbHCIjXE5TRGljdGlvbmFyeaIiIF8QD05TS2V5ZWRBcmNoaXZlctEmJ1Ryb290gAEACAARABoAIwAtADIANwBAAEYATQBVAGAAZwBqAGwAbgBxAHMAdQB3AIQAjgDyAPcA/wNXA1kDXgNpA3IDgAOEA4sDlAOZA6YDqQO7A74DwwAAAAAAAAIBAAAAAAAAACgAAAAAAAAAAAAAAAAAAAPF}}
-
-@article{Siegler87,
-	Author = {Robert S. Siegler},
-	Date-Added = {2014-08-21 21:00:35 +0000},
-	Date-Modified = {2014-08-21 21:00:35 +0000},
-	Journal = {Journal of Experimental Psychology: General},
-	Keywords = {Multiple strategy use; mathematics education; strategies; learning sciences; psychology},
-	Number = {3},
-	Pages = {250-264},
-	Title = {The perils of averaging data over strategies: An example from children's addition},
-	Volume = {116},
-	Year = {1987},
-	Bdsk-File-1 = {YnBsaXN0MDDUAQIDBAUGJCVYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoKgHCBMUFRYaIVUkbnVsbNMJCgsMDxJXTlMua2V5c1pOUy5vYmplY3RzViRjbGFzc6INDoACgAOiEBGABIAFgAdccmVsYXRpdmVQYXRoWWFsaWFzRGF0YV8Qby4uLy4uLy4uL0RvY3VtZW50cy9Kb3VybmFsLU5ld3MtQXJ0aWNsZXMvTGVhcm5pbmcgU2NpZW5jZXMsIExBLCBFRE0vU2llZ2xlci04Ny1NdWx0aXBsZSBBZGRpdGlvbiBTdHJhdGVnaWVzLnBkZtIXCxgZV05TLmRhdGFPEQJoAAAAAAJoAAIAAAxNYWNpbnRvc2ggSEQAAAAAAAAAAAAAAAAAAADLaacfSCsAAAALnbIfU2llZ2xlci04Ny1NdWx0aXBsZSBBI0I5RTE1LnBkZgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAueFcjZ9odQREYgAAAAAAADAAQAAAkgAAAAAAAAAAAAAAAAAAAAGkxlYXJuaW5nIFNjaWVuY2VzLCBMQSwgRURNABAACAAAy2ntbwAAABEACAAAyNouxwAAAAEAFAALnbIAC5wCAAXInwAFyJ4AALlXAAIAfE1hY2ludG9zaCBIRDpVc2VyczoAYWdhbHlhcmR0OgBEb2N1bWVudHM6AEpvdXJuYWwtTmV3cy1BcnRpY2xlczoATGVhcm5pbmcgU2NpZW5jZXMsIExBLCBFRE06AFNpZWdsZXItODctTXVsdGlwbGUgQSNCOUUxNS5wZGYADgBYACsAUwBpAGUAZwBsAGUAcgAtADgANwAtAE0AdQBsAHQAaQBwAGwAZQAgAEEAZABkAGkAdABpAG8AbgAgAFMAdAByAGEAdABlAGcAaQBlAHMALgBwAGQAZgAPABoADABNAGEAYwBpAG4AdABvAHMAaAAgAEgARAASAHZVc2Vycy9hZ2FseWFyZHQvRG9jdW1lbnRzL0pvdXJuYWwtTmV3cy1BcnRpY2xlcy9MZWFybmluZyBTY2llbmNlcywgTEEsIEVETS9TaWVnbGVyLTg3LU11bHRpcGxlIEFkZGl0aW9uIFN0cmF0ZWdpZXMucGRmABMAAS8AABUAAgAQ//8AAIAG0hscHR5aJGNsYXNzbmFtZVgkY2xhc3Nlc11OU011dGFibGVEYXRhox0fIFZOU0RhdGFYTlNPYmplY3TSGxwiI1xOU0RpY3Rpb25hcnmiIiBfEA9OU0tleWVkQXJjaGl2ZXLRJidUcm9vdIABAAgAEQAaACMALQAyADcAQABGAE0AVQBgAGcAagBsAG4AcQBzAHUAdwCEAI4BAAEFAQ0DeQN7A4ADiwOUA6IDpgOtA7YDuwPIA8sD3QPgA+UAAAAAAAACAQAAAAAAAAAoAAAAAAAAAAAAAAAAAAAD5w==}}
-
-@article{Chi81,
-	Author = {Chi, Michelene T.H. and Feltovich, Paul J. and Glaser, Robert},
-	Date-Added = {2014-08-21 21:00:27 +0000},
-	Date-Modified = {2014-08-21 21:00:27 +0000},
-	Journal = {Cognitive science},
-	Keywords = {expert/novice differences},
-	Number = {2},
-	Pages = {121--152},
-	Publisher = {Wiley Online Library},
-	Title = {Categorization and representation of physics problems by experts and novices},
-	Volume = {5},
-	Year = {1981},
-	Bdsk-File-1 = {YnBsaXN0MDDUAQIDBAUGJCVYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoKgHCBMUFRYaIVUkbnVsbNMJCgsMDxJXTlMua2V5c1pOUy5vYmplY3RzViRjbGFzc6INDoACgAOiEBGABIAFgAdccmVsYXRpdmVQYXRoWWFsaWFzRGF0YV8QZy4uLy4uL1BhcGVyLVdoYXQncyBhIFN0cmF0ZWd5L1BhcGVycy1TdHJhdGVnaWVzL1JlYWQvQ2hpLCBGZWx0b3ZpY2gsIEdsYXNlciAoMTk4MSktcGh5c2ljcyBwcm9ibGVtcy5wZGbSFwsYGVdOUy5kYXRhTxECZgAAAAACZgACAAAMTWFjaW50b3NoIEhEAAAAAAAAAAAAAAAAAAAAybeLVUgrAAACeKY6H0NoaSwgRmVsdG92aWNoLCBHbGEjMjc4QTdDQy5wZGYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJ4p8zP6ZB8AAAAAAAAAAAAAgAEAAAJIAAAAAAAAAAAAAAAAAAAAARSZWFkABAACAAAybfDlQAAABEACAAAz+nIvAAAAAEAGAJ4pjoCeKY4ANZobAAXn1sADVHYAACYOgACAHlNYWNpbnRvc2ggSEQ6VXNlcnM6AGFnYWx5YXJkdDoARHJvcGJveDoAUGFwZXItV2hhdCdzIGEgU3RyYXRlZ3k6AFBhcGVycy1TdHJhdGVnaWVzOgBSZWFkOgBDaGksIEZlbHRvdmljaCwgR2xhIzI3OEE3Q0MucGRmAAAOAGYAMgBDAGgAaQAsACAARgBlAGwAdABvAHYAaQBjAGgALAAgAEcAbABhAHMAZQByACAAKAAxADkAOAAxACkALQBwAGgAeQBzAGkAYwBzACAAcAByAG8AYgBsAGUAbQBzAC4AcABkAGYADwAaAAwATQBhAGMAaQBuAHQAbwBzAGgAIABIAEQAEgB5VXNlcnMvYWdhbHlhcmR0L0Ryb3Bib3gvUGFwZXItV2hhdCdzIGEgU3RyYXRlZ3kvUGFwZXJzLVN0cmF0ZWdpZXMvUmVhZC9DaGksIEZlbHRvdmljaCwgR2xhc2VyICgxOTgxKS1waHlzaWNzIHByb2JsZW1zLnBkZgAAEwABLwAAFQACABD//wAAgAbSGxwdHlokY2xhc3NuYW1lWCRjbGFzc2VzXU5TTXV0YWJsZURhdGGjHR8gVk5TRGF0YVhOU09iamVjdNIbHCIjXE5TRGljdGlvbmFyeaIiIF8QD05TS2V5ZWRBcmNoaXZlctEmJ1Ryb290gAEACAARABoAIwAtADIANwBAAEYATQBVAGAAZwBqAGwAbgBxAHMAdQB3AIQAjgD4AP0BBQNvA3EDdgOBA4oDmAOcA6MDrAOxA74DwQPTA9YD2wAAAAAAAAIBAAAAAAAAACgAAAAAAAAAAAAAAAAAAAPd}}
-
-@incollection{Mislevy06Cog,
-	Author = {Robert Mislevy},
-	Booktitle = {Educational Assessment},
-	Chapter = {8},
-	Date-Added = {2014-08-21 20:58:59 +0000},
-	Date-Modified = {2014-08-21 20:58:59 +0000},
-	Editor = {Robert L. Brennan},
-	Publisher = {American Council on Education and Praeger Publishers},
-	Title = {Cognitive Psychology and Educational Assessment},
-	Year = {2006},
-	Bdsk-File-1 = {YnBsaXN0MDDUAQIDBAUGJCVYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoKgHCBMUFRYaIVUkbnVsbNMJCgsMDxJXTlMua2V5c1pOUy5vYmplY3RzViRjbGFzc6INDoACgAOiEBGABIAFgAdccmVsYXRpdmVQYXRoWWFsaWFzRGF0YV8QUy4uLy4uL1BhcGVyLVdoYXQncyBhIFN0cmF0ZWd5L1BhcGVycy1Nb2RlbHMvTWlzbGV2eSAoMjAwNiktQ29nIFBzeSAmIEFzc2Vzc21lbnQucGRm0hcLGBlXTlMuZGF0YU8RAjgAAAAAAjgAAgAADE1hY2ludG9zaCBIRAAAAAAAAAAAAAAAAAAAAMm3i1VIKwAAAnimNh9NaXNsZXZ5ICgyMDA2KS1Db2cgIzI3QjBENEIucGRmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACew1Lz+7ulQAAAAAAAAAAAAIAAwAACSAAAAAAAAAAAAAAAAAAAAANUGFwZXJzLU1vZGVscwAAEAAIAADJt8OVAAAAEQAIAADP7ybVAAAAAQAUAnimNgDWaGwAF59bAA1R2AAAmDoAAgBvTWFjaW50b3NoIEhEOlVzZXJzOgBhZ2FseWFyZHQ6AERyb3Bib3g6AFBhcGVyLVdoYXQncyBhIFN0cmF0ZWd5OgBQYXBlcnMtTW9kZWxzOgBNaXNsZXZ5ICgyMDA2KS1Db2cgIzI3QjBENEIucGRmAAAOAFAAJwBNAGkAcwBsAGUAdgB5ACAAKAAyADAAMAA2ACkALQBDAG8AZwAgAFAAcwB5ACAAJgAgAEEAcwBzAGUAcwBzAG0AZQBuAHQALgBwAGQAZgAPABoADABNAGEAYwBpAG4AdABvAHMAaAAgAEgARAASAGVVc2Vycy9hZ2FseWFyZHQvRHJvcGJveC9QYXBlci1XaGF0J3MgYSBTdHJhdGVneS9QYXBlcnMtTW9kZWxzL01pc2xldnkgKDIwMDYpLUNvZyBQc3kgJiBBc3Nlc3NtZW50LnBkZgAAEwABLwAAFQACABD//wAAgAbSGxwdHlokY2xhc3NuYW1lWCRjbGFzc2VzXU5TTXV0YWJsZURhdGGjHR8gVk5TRGF0YVhOU09iamVjdNIbHCIjXE5TRGljdGlvbmFyeaIiIF8QD05TS2V5ZWRBcmNoaXZlctEmJ1Ryb290gAEACAARABoAIwAtADIANwBAAEYATQBVAGAAZwBqAGwAbgBxAHMAdQB3AIQAjgDkAOkA8QMtAy8DNAM/A0gDVgNaA2EDagNvA3wDfwORA5QDmQAAAAAAAAIBAAAAAAAAACgAAAAAAAAAAAAAAAAAAAOb}}
-
-@article{Mislevy12,
-	Author = {Robert J. Mislevy and John T. Behrens and Kristen E. {DiCerbo} and Roy Levy},
-	Date-Added = {2014-03-27 15:22:33 +0000},
-	Date-Modified = {2014-03-27 15:22:33 +0000},
-	Journal = {Journal of Educational Data Mining},
-	Number = {1},
-	Title = {Design and Discovery in Educational Assessment: Evidence-Centered Design, Psychometrics, and Educational Data Mining},
-	Volume = {4},
-	Year = {2012},
-	Bdsk-File-1 = {YnBsaXN0MDDUAQIDBAUGJCVYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoKgHCBMUFRYaIVUkbnVsbNMJCgsMDxJXTlMua2V5c1pOUy5vYmplY3RzViRjbGFzc6INDoACgAOiEBGABIAFgAdccmVsYXRpdmVQYXRoWWFsaWFzRGF0YV8QWC4uLy4uL1ByaXZhdGUtRVJTSDg5OTAvUmVhZGluZ0xpc3QvQ29waWVzX1VubWFya2VkX0Rpc3RyaWJ1dGUvUjEtTWlzbGV2eSBldGFsICgyMDEyKS5wZGbSFwsYGVdOUy5kYXRhTxECQAAAAAACQAACAAAMTWFjaW50b3NoIEhEAAAAAAAAAAAAAAAAAAAAybeLVUgrAAACIbwqGlIxLU1pc2xldnkgZXRhbCAoMjAxMikucGRmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIhvEDPPjaUAAAAAAAAAAAAAgAEAAAJIAAAAAAAAAAAAAAAAAAAABpDb3BpZXNfVW5tYXJrZWRfRGlzdHJpYnV0ZQAQAAgAAMm3w5UAAAARAAgAAM8+fOQAAAABABgCIbwqAiG8JQCmuWsAF59bAA1R2AAAmDoAAgB9TWFjaW50b3NoIEhEOlVzZXJzOgBhZ2FseWFyZHQ6AERyb3Bib3g6AFByaXZhdGUtRVJTSDg5OTA6AFJlYWRpbmdMaXN0OgBDb3BpZXNfVW5tYXJrZWRfRGlzdHJpYnV0ZToAUjEtTWlzbGV2eSBldGFsICgyMDEyKS5wZGYAAA4ANgAaAFIAMQAtAE0AaQBzAGwAZQB2AHkAIABlAHQAYQBsACAAKAAyADAAMQAyACkALgBwAGQAZgAPABoADABNAGEAYwBpAG4AdABvAHMAaAAgAEgARAASAGpVc2Vycy9hZ2FseWFyZHQvRHJvcGJveC9Qcml2YXRlLUVSU0g4OTkwL1JlYWRpbmdMaXN0L0NvcGllc19Vbm1hcmtlZF9EaXN0cmlidXRlL1IxLU1pc2xldnkgZXRhbCAoMjAxMikucGRmABMAAS8AABUAAgAQ//8AAIAG0hscHR5aJGNsYXNzbmFtZVgkY2xhc3Nlc11OU011dGFibGVEYXRhox0fIFZOU0RhdGFYTlNPYmplY3TSGxwiI1xOU0RpY3Rpb25hcnmiIiBfEA9OU0tleWVkQXJjaGl2ZXLRJidUcm9vdIABAAgAEQAaACMALQAyADcAQABGAE0AVQBgAGcAagBsAG4AcQBzAHUAdwCEAI4A6QDuAPYDOgM8A0EDTANVA2MDZwNuA3cDfAOJA4wDngOhA6YAAAAAAAACAQAAAAAAAAAoAAAAAAAAAAAAAAAAAAADqA==}}
-
-@incollection{VanLehn08,
-	Author = {Kurt VanLehn},
-	Booktitle = {The future of assessment: Shaping teaching and learning.},
-	Date-Added = {2014-03-27 14:52:29 +0000},
-	Date-Modified = {2014-03-27 14:54:32 +0000},
-	Editor = {C. Dwyer},
-	Keywords = {intelligent tutoring systems},
-	Pages = {113-138},
-	Publisher = {Erbaum},
-	Title = {Intelligent Tutoring Systems for Continuous, Embedded Assessment},
-	Year = {2008},
-	Bdsk-File-1 = {YnBsaXN0MDDUAQIDBAUGJCVYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoKgHCBMUFRYaIVUkbnVsbNMJCgsMDxJXTlMua2V5c1pOUy5vYmplY3RzViRjbGFzc6INDoACgAOiEBGABIAFgAdccmVsYXRpdmVQYXRoWWFsaWFzRGF0YV8QXS4uLy4uL05ldyBBcnRpY2xlcy9SZWFkL1ZhbkxlaG4oMjAwOCktIEludGVsbGlnZW50IHR1dG9yaW5nIHN5c3RlbXMgZm9yIGNvbnRpbnVvdXMsIGVtYmVkLnBkZtIXCxgZV05TLmRhdGFPEQJgAAAAAAJgAAIAAAxNYWNpbnRvc2ggSEQAAAAAAAAAAAAAAAAAAADJt4tVSCsAAAE5yhcfVmFuTGVobigyMDA4KS0gSW50ZSMyMkY0MUFFLnBkZgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAi9Brs9Zst0AAAAAAAAAAAACAAMAAAkgAAAAAAAAAAAAAAAAAAAABFJlYWQAEAAIAADJt8OVAAAAEQAIAADPWesdAAAAAQAUATnKFwAb8HgAF59bAA1R2AAAmDoAAgBbTWFjaW50b3NoIEhEOlVzZXJzOgBhZ2FseWFyZHQ6AERyb3Bib3g6AE5ldyBBcnRpY2xlczoAUmVhZDoAVmFuTGVobigyMDA4KS0gSW50ZSMyMkY0MUFFLnBkZgAADgCMAEUAVgBhAG4ATABlAGgAbgAoADIAMAAwADgAKQAtACAASQBuAHQAZQBsAGwAaQBnAGUAbgB0ACAAdAB1AHQAbwByAGkAbgBnACAAcwB5AHMAdABlAG0AcwAgAGYAbwByACAAYwBvAG4AdABpAG4AdQBvAHUAcwAsACAAZQBtAGIAZQBkAC4AcABkAGYADwAaAAwATQBhAGMAaQBuAHQAbwBzAGgAIABIAEQAEgBvVXNlcnMvYWdhbHlhcmR0L0Ryb3Bib3gvTmV3IEFydGljbGVzL1JlYWQvVmFuTGVobigyMDA4KS0gSW50ZWxsaWdlbnQgdHV0b3Jpbmcgc3lzdGVtcyBmb3IgY29udGludW91cywgZW1iZWQucGRmAAATAAEvAAAVAAIAEP//AACABtIbHB0eWiRjbGFzc25hbWVYJGNsYXNzZXNdTlNNdXRhYmxlRGF0YaMdHyBWTlNEYXRhWE5TT2JqZWN00hscIiNcTlNEaWN0aW9uYXJ5oiIgXxAPTlNLZXllZEFyY2hpdmVy0SYnVHJvb3SAAQAIABEAGgAjAC0AMgA3AEAARgBNAFUAYABnAGoAbABuAHEAcwB1AHcAhACOAO4A8wD7A18DYQNmA3EDegOIA4wDkwOcA6EDrgOxA8MDxgPLAAAAAAAAAgEAAAAAAAAAKAAAAAAAAAAAAAAAAAAAA80=}}
-
-@article{Erosheva04,
-	Author = {Elena Erosheva and Stephen E. Fienberg and John Lafferty},
-	Date-Added = {2013-12-18 14:22:42 +0000},
-	Date-Modified = {2013-12-18 14:25:57 +0000},
-	Journal = {PNAS},
-	Number = {Suppl.1},
-	Pages = {5220-5227},
-	Title = {Mixed-Membership Models of Scientific Publications},
-	Volume = {101},
-	Year = {2004},
-	Bdsk-Url-1 = {http://www.pnas.org/cgi/content/full/101/suppl_1/5220}}
-
-@incollection{Blei09,
-	Author = {David Blei and John Lafferty},
-	Booktitle = {Text Mining: Classification, Clustering, and Applications},
-	Date-Added = {2013-12-18 14:09:12 +0000},
-	Date-Modified = {2013-12-18 14:12:00 +0000},
-	Editor = {A. Srivastava and M. Sahami},
-	Publisher = {Chapman \& Hall/CRC},
-	Series = {Data Mining and Knowledge Discovery Series},
-	Title = {Topic Models},
-	Year = {2009},
-	Bdsk-Url-1 = {http://www.cs.princeton.edu/~blei/papers/BleiLafferty2009.pdf}}
-
-@article{aleven_toward_2006,
-	Author = {Aleven, V. and Mclaren, B. and Roll, I. and Koedinger, K.},
-	Date-Added = {2013-12-05 22:14:42 +0000},
-	Date-Modified = {2013-12-17 17:12:03 +0000},
-	Issue = {2},
-	Journal = {International Journal of Artificial Intelligence in Education},
-	Pages = {101-128},
-	Title = {Toward meta-cognitive tutoring: A model of help seeking with a Cognitive Tutor},
-	Volume = {16},
-	Year = {2006}}
-
-@inproceedings{goldin_hints:_2013,
-	Author = {Goldin, Ilya M. and Koedinger, Kenneth R. and Aleven, Vincent A. W. M. M.},
-	Booktitle = {Proceedings of 6th International Conference on Educational Data Mining},
-	Date-Added = {2013-12-05 22:14:42 +0000},
-	Date-Modified = {2013-12-17 19:51:31 +0000},
-	Editor = {{D'Mello}, Sidney K. and Calvo, Rafael A. and Olney, Andrew},
-	Location = {Memphis, {TN}},
-	Month = {July},
-	Title = {Hints: You Can't Have Just One},
-	Year = {2013},
-	Bdsk-Url-1 = {http://www.educationaldatamining.org/EDM2013/papers/rn_paper_35.pdf}}
-
-@inproceedings{goldin_learner_2012,
-	Address = {Chania, Greece},
-	Author = {Goldin, Ilya M. and Koedinger, Kenneth R. and Aleven, Vincent A. W. M. M.},
-	Booktitle = {Proceedings of 5th International Conference on Educational Data Mining},
-	Date-Added = {2013-12-05 22:14:42 +0000},
-	Date-Modified = {2013-12-17 19:50:21 +0000},
-	Editor = {Yacef, Kalina and Za{\"\i}ane, Osmar and Hershkovitz, Arnon and Yudelson, Michael and Stamper, John},
-	Pages = {73-80},
-	Title = {Learner Differences in Hint Processing},
-	Year = {2012},
-	Bdsk-Url-1 = {http://educationaldatamining.org/EDM2012/uploads/procs/Full_Papers/edm2012_full_6.pdf}}
-
-@inproceedings{goldin_learner_2013,
-	Address = {Memphis, {TN}},
-	Author = {Goldin, Ilya M. and Carlson, Ryan},
-	Booktitle = {Proceedings of 16th International Conference on Artificial Intelligence in Education},
-	Date-Added = {2013-12-05 22:14:42 +0000},
-	Date-Modified = {2013-12-17 17:14:16 +0000},
-	Title = {Learner Differences and Hint Content},
-	Year = {2013}}
-
-@article{Girolami05,
-	Abstract = {To provide a parsimonious generative representation of the sequential activity of a number of individuals within a population there is a necessary tradeoff between the definition of individual specific and global 
-representations. A linear-time algorithm is proposed that defines a distributed predictive model for finite state symbolic sequences which represent the traces of the activity of a number of individuals within a group. The algorithm is based on a straightforward generalization of latent Dirichlet allocation to time-invariant Markov chains of arbitrary order. The modelling assumption made is that the possibly heterogeneous behavior of individuals may be represented by a relatively small number of simple and common behavioral traits which may interleave randomly according to an individual-specific distribution. The results of an empirical study on three different application domains indicate that this modelling approach provides an efficient low-complexity and intuitively interpretable representation scheme which is reflected by improved prediction performance over comparable models.},
-	Annote = {Builds a mixed-membership model where the basis profiles are markov chains of varying order. 
-Uses two types of estimation: Variational approximation, and "maximum a posteriori" (MAP)
-Fits model on 3 different data sets of user-log data: actions in a word processor, sequences of calls to different geographic regions (UK), and finally web page browsing. 
-
-Compares models on "perplexity" which they define as the exponential of the negative-normalized log-likelihood.  (Might be a standard markov-chain goodness of fit measure, or it might be more standard to ML)
-They use t-tests and non-parametric Wilcoxon Rank-Sum tests to test for significant differences in perplexity.
-
-They call their model a "simplical mixture of markov chains" and cite Minka and Lafferty 2002. 
-
-For the zero^th order Markov model (when no memory is assumed in the markov process), then their model reduces to a multinomial LDA model. 
-
-They also claim that Hofmann's pLSA algorithm is equivalent to LDA when the MAP estimator is calculated through an iterative convergence method. Suggests that LDA is an improvement over pLSA because of the estimation method used.  Cites Lappalainen and Miskin (2000) on the weakness of MAP estimators. 
-
-For all the data sets, the mixed-membership model offers better results. Better on the goodness-of-fit measures and more interpretable results.  The differences were clearer on the bigger data sets with larger state-spaces. 
-
-Data Structure:  only 1 item per model - the sequences (J=1)
-	many replications of each item (big R) 
-
-They offer some additional comments on computational algorithms and computational time.},
-	Author = {Mark Girolami and Ata Kaban},
-	Date-Added = {2013-06-25 19:41:00 +0000},
-	Date-Modified = {2013-06-25 19:41:00 +0000},
-	Journal = {Data Mining and Knowledge Discovery},
-	Keywords = {Latent Dirichlet Allocation, markov chains, Mixture models, user profiling, mixed membership, variational approximation},
-	Pages = {175-196},
-	Title = {Sequential Activity Profiling: Latent Dirichlet Allocation of Markov Chains},
-	Volume = {10},
-	Year = {2005},
-	Bdsk-File-1 = {YnBsaXN0MDDUAQIDBAUGJCVYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoKgHCBMUFRYaIVUkbnVsbNMJCgsMDxJXTlMua2V5c1pOUy5vYmplY3RzViRjbGFzc6INDoACgAOiEBGABIAFgAdccmVsYXRpdmVQYXRoWWFsaWFzRGF0YV8Qay4uLy4uLy4uL0RvY3VtZW50cy9Kb3VybmFsLU5ld3MtQXJ0aWNsZXMvTWl4ZWQgTWVtYmVyc2hpcC9HaXJvbGFtaSAmIEthYmFuICgyMDA1KS0gTERBIG9mIG1hcmtvdiBjaGFpbnMucGRm0hcLGBlXTlMuZGF0YU8RAlwAAAAAAlwAAgAADE1hY2ludG9zaCBIRAAAAAAAAAAAAAAAAAAAAMtppx9IKwAAAAueSx9HaXJvbGFtaSAmIEthYmFuICgyMDAjQjlFNkEucGRmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC55qyVXqE1BERiAAAAAAAAMABAAACSAAAAAAAAAAAAAAAAAAAAAQTWl4ZWQgTWVtYmVyc2hpcAAQAAgAAMtp7W8AAAARAAgAAMlWMGMAAAABABQAC55LAAucAgAFyJ8ABcieAAC5VwACAHJNYWNpbnRvc2ggSEQ6VXNlcnM6AGFnYWx5YXJkdDoARG9jdW1lbnRzOgBKb3VybmFsLU5ld3MtQXJ0aWNsZXM6AE1peGVkIE1lbWJlcnNoaXA6AEdpcm9sYW1pICYgS2FiYW4gKDIwMCNCOUU2QS5wZGYADgBkADEARwBpAHIAbwBsAGEAbQBpACAAJgAgAEsAYQBiAGEAbgAgACgAMgAwADAANQApAC0AIABMAEQAQQAgAG8AZgAgAG0AYQByAGsAbwB2ACAAYwBoAGEAaQBuAHMALgBwAGQAZgAPABoADABNAGEAYwBpAG4AdABvAHMAaAAgAEgARAASAHJVc2Vycy9hZ2FseWFyZHQvRG9jdW1lbnRzL0pvdXJuYWwtTmV3cy1BcnRpY2xlcy9NaXhlZCBNZW1iZXJzaGlwL0dpcm9sYW1pICYgS2FiYW4gKDIwMDUpLSBMREEgb2YgbWFya292IGNoYWlucy5wZGYAEwABLwAAFQACABD//wAAgAbSGxwdHlokY2xhc3NuYW1lWCRjbGFzc2VzXU5TTXV0YWJsZURhdGGjHR8gVk5TRGF0YVhOU09iamVjdNIbHCIjXE5TRGljdGlvbmFyeaIiIF8QD05TS2V5ZWRBcmNoaXZlctEmJ1Ryb290gAEACAARABoAIwAtADIANwBAAEYATQBVAGAAZwBqAGwAbgBxAHMAdQB3AIQAjgD8AQEBCQNpA2sDcAN7A4QDkgOWA50DpgOrA7gDuwPNA9AD1QAAAAAAAAIBAAAAAAAAACgAAAAAAAAAAAAAAAAAAAPX}}

--- a/template.qmd
+++ b/template.qmd
@@ -31,19 +31,6 @@ bibliography: bibliography.bib
 Body of paper.
 Margins in this document are roughly 0.75 inches all around, letter size paper.
 
-```{r}
-#| label: fig-scatter1
-#| echo: false
-#| message: false
-#| warning: false
-#| fig-cap: A not very interesting scatterplot
-library(tidyverse)
-ds <- tibble(x = 1:5, y = 5:1)
-ggplot(ds, aes(x = x, y = y)) + geom_point()
-```
-
-@fig-scatter1 displays a non-stochastic relationship.
-
 
 ![Consistency comparison in fitting surrogate model in the tidal power example.](fig1.pdf){#fig-first width=3in}
 
@@ -228,7 +215,7 @@ R-package for  MYNEW routine:
 
 HIV data set:
 
-:   Data set used in the illustration of MYNEW method in Section~ 3.2. (.txt file)
+:   Data set used in the illustration of MYNEW method in @sec-verify (.txt file).
 
 ## BibTeX 
 

--- a/template.qmd
+++ b/template.qmd
@@ -10,7 +10,7 @@ date: last-modified
 author:
   - name: Author 1
     acknowledgements: | 
-      The authors gratefully acknowledge _please remember to list all relevant funding sources in the unblinded version_.
+      The authors gratefully acknowledge _please remember to list all relevant funding sources in the non-anonymized (unblinded) version_.
     affiliations:
       - name: University of XXX
         department: Department of YYY
@@ -28,8 +28,22 @@ bibliography: bibliography.bib
 
 ## Introduction {#sec-intro}
 
-Body of paper.  Margins in this document are roughly 0.75 inches all
-around, letter size paper.
+Body of paper.
+Margins in this document are roughly 0.75 inches all around, letter size paper.
+
+```{r}
+#| label: fig-scatter1
+#| echo: false
+#| message: false
+#| warning: false
+#| fig-cap: A not very interesting scatterplot
+library(tidyverse)
+ds <- tibble(x = 1:5, y = 5:1)
+ggplot(ds, aes(x = x, y = y)) + geom_point()
+```
+
+@fig-scatter1 displays a non-stochastic relationship.
+
 
 ![Consistency comparison in fitting surrogate model in the tidal power example.](fig1.pdf){#fig-first width=3in}
 
@@ -42,12 +56,12 @@ around, letter size paper.
 : D-optimality values for design X under five different scenarios. {#tbl-one}
 
 - Note that figures and tables (such as @fig-first and @tbl-one) should appear in the paper, not at the end or in separate files.
-- In document front matter, you may set the key `blinded` under a `journal` key to hide the authors and acknowledgements, producing the required blinded version.
-- Remember that in the blind version, you should not identify authors indirectly in the text.  That is, don't say "In Smith et. al.  (2009) we showed that ...". Instead, say "Smith et. al. (2009) showed that ...".
+- In document front matter, you may set the key `blinded` under a `journal` key to hide the authors and acknowledgements, producing the required anonymized version.
+- Remember that in the anonymized version, you should not identify authors indirectly in the text.  That is, don't say "In Smith et. al.  (2009) we showed that ...". Instead, say "Smith et. al. (2009) showed that ...".
 - These points are only intended to remind you of some requirements.
 Please refer to the instructions for authors
 at [http://amstat.tandfonline.com/action/authorSubmission?journalCode=uasa20&page=instructions#.VFkk7fnF_0c](http://amstat.tandfonline.com/action/authorSubmission?journalCode=uasa20&page=instructions#.VFkk7fnF_0c)
-- For more about ASA\ style, please see [http://journals.taylorandfrancis.com/amstat/asa-style-guide/](http://journals.taylorandfrancis.com/amstat/asa-style-guide/)
+- For more about ASA\ style, please see [https://files.taylorandfrancis.com/asa-style-guide.pdf](https://files.taylorandfrancis.com/asa-style-guide.pdf).
 - If you have supplementary material (e.g., software, data, technical
 proofs), identify them in the section below.  In early stages of the
 submission process, you may be unsure what to include as supplementary
@@ -55,18 +69,19 @@ material.  Don't worry---this is something that can be worked out at later stage
 
 ## Methods {#sec-meth}
 
-Don't take any of these section titles seriously.  They're just for
-illustration.
+Don't take any of these section titles seriously.
+They're just for illustration.
 
 ## Verifications {#sec-verify}
 
-This section will be just long enough to illustrate what a full page of
-text looks like, for margins and spacing.
+This section will be just long enough to illustrate what a full page of text looks like, for margins and spacing.
 
 
 :::{add-textheight=".5in"}
 
-@Campbell02, @Schubert13, @Chi81
+@gelm:veht:2021 offer some guidance about key ideas about statistical ideas.
+On an unrelated note, spreadsheets are important to use correctly [@brom:woo:2018].
+Log-linear models are an attractive way to model categorical data [@bish:fien:1975].
 
 The quick brown fox jumped over the lazy dog.
 The quick brown fox jumped over the lazy dog.
@@ -100,8 +115,6 @@ The quick brown fox jumped over the lazy dog.
 The quick brown fox jumped over the lazy dog.
 The quick brown fox jumped over the lazy dog.
 The quick brown fox jumped over the lazy dog.
-
-%new margin nere
 
 The quick brown fox jumped over the lazy dog.
 The quick brown fox jumped over the lazy dog.
@@ -194,6 +207,14 @@ The quick brown fox jumped over the lazy dog.
 
 ## Conclusion {#sec-conc}
 
+## Disclosure statement
+
+The authors have the following conflicts of interest to declare (or replace with a statement that no conflicts of interest exist).
+
+## Data Availability Statement
+
+Deidentified data have been made available at the following URL: XX.
+
 ## Supplementary Material {.supplementary}
 
 Title:
@@ -211,4 +232,5 @@ HIV data set:
 
 ## BibTeX 
 
-We hope you've chosen to use BibTeX! If you have, please feel free to use the package natbib with any bibliography style you're comfortable with. The .bst file agsm has been included here for your convenience. 
+We hope you've chosen to use BibTeX!
+If you have, please feel free to use the package natbib with any bibliography style you're comfortable with. The .bst file agsm has been included here for your convenience. 

--- a/template.qmd
+++ b/template.qmd
@@ -232,5 +232,5 @@ HIV data set:
 
 ## BibTeX 
 
-We hope you've chosen to use BibTeX!
+We encourage you to use BibTeX.
 If you have, please feel free to use the package natbib with any bibliography style you're comfortable with. The .bst file agsm has been included here for your convenience. 


### PR DESCRIPTION
I *love* the JASA quarto template and thank you profusely for putting it together.

I've been in touch with Eric Sampson (ASA Journals Manager) about updating their .tex template to account for a number of changes, including updating the refs to more relevant ones, listing of DOI's/URL's and capitalizing reference title words. I've also made some other light edits (wording re: BibTeX and inclusion of a figure generated in R).

I'd welcome any thoughts about whether it might be reasonable to make these changes to your excellent template.